### PR TITLE
feat: show text on hover of icons

### DIFF
--- a/amstel/VIew/WalletView.swift
+++ b/amstel/VIew/WalletView.swift
@@ -56,8 +56,10 @@ struct WalletView: View {
                 if isConnected {
                     Image(systemName: "network")
                         .foregroundStyle(.green)
+                        .help(NETWORK == .bitcoin ? "Connected to Bitcoin network" : "Connected to Bitcoin \(NETWORK) network")
                 } else {
                     Image(systemName: "network.slash")
+                        .help(NETWORK == .bitcoin ? "Disconnected from Bitcoinnetwork" : "Disconnected from Bitcoin \(NETWORK) network")
                 }
             }
             .padding()
@@ -92,6 +94,7 @@ struct WalletView: View {
                 }
                 .keyboardShortcut("n", modifiers: [.command])
                 .disabled(isInitialLoad || errorMessage != nil || isInitialSync)
+                .help("Create a transaction")
                 Button(action: {
                     if let url = openPsbtFile() {
                         do {
@@ -105,6 +108,7 @@ struct WalletView: View {
                     Label("Send", systemImage: "paperplane")
                 }
                 .keyboardShortcut("b", modifiers: [.command])
+                .help("Send a transaction")
                 Button(action: {
                     do {
                         self.currentRevealed = try self.walletState.receive()
@@ -117,6 +121,7 @@ struct WalletView: View {
                 }
                 .keyboardShortcut("r", modifiers: [.command])
                 .disabled(isInitialLoad || errorMessage != nil || isInitialSync)
+                .help("Generate a receive address")
             }
         }
         // User flow sheets


### PR DESCRIPTION
icons only are nice

<img width="168" height="112" alt="Screenshot 2025-07-11 at 9 55 02 AM" src="https://github.com/user-attachments/assets/bbec339c-d301-44bb-8b7d-983763794c64" />

this PR just adds a hover state to them in case someone isn't sure what the icon is for exactly (and doesnt want to click it because of that), for example here is the hover state now on the send button:

<img width="199" height="68" alt="Screenshot 2025-07-11 at 9 55 32 AM" src="https://github.com/user-attachments/assets/bec616da-a65d-4bfa-9e59-082ce940223d" />
