### PR TITLE
feat: settings button to open data dir

### DIFF
--- a/amstel/VIew/SettingsView.swift
+++ b/amstel/VIew/SettingsView.swift
@@ -11,6 +11,14 @@ struct SettingsView: View {
     @AppStorage("numConns") private var numConns: Int = 3
     @AppStorage("useProxy") private var useProxy: Bool = false
 
+    private func openDataDirectory() {
+        let fileManager = FileManager.default
+        if let containerURL = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first {
+            let appSupportURL = containerURL.deletingLastPathComponent()
+            NSWorkspace.shared.open(appSupportURL)
+        }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -29,6 +37,17 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                         
                     }
+                    
+                    Divider()
+                        .padding(.vertical, 8)
+                    
+                    Button(action: openDataDirectory) {
+                        HStack {
+                            Image(systemName: "folder")
+                            Text("Open Data Directory")
+                        }
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }


### PR DESCRIPTION
should open up `amstel` folder

optional whether you want this, at least as a dev its nice to have a quick way to get to data dir, I can see how maybe for users you might not want this?