### PR TITLE
Apply unconfirmed transactions to `Wallet`

### DIFF
--- a/amstel/Extensions/BDK.swift
+++ b/amstel/Extensions/BDK.swift
@@ -36,10 +36,10 @@ extension LocalOutput {
 extension CanonicalTx {
     func intoMetadata() -> TxMetadata {
         let txid = transaction.computeTxid().description
-        let (chainPos, time) = switch chainPosition {
+        let (chainPos, time): (UInt32?, Date) = switch chainPosition {
         case let .confirmed(confirmation_block_time, _):
             (confirmation_block_time.blockId.height, Date(timeIntervalSince1970: TimeInterval(confirmation_block_time.confirmationTime)))
-        case .unconfirmed: (UInt32(0), Date())
+        case .unconfirmed: (nil, Date())
         }
         return TxMetadata(txid: txid, date: time, height: chainPos)
     }

--- a/amstel/Model/Transaction.swift
+++ b/amstel/Model/Transaction.swift
@@ -17,5 +17,5 @@ struct ViewableTransaction: Equatable, Identifiable, Hashable {
 struct TxMetadata: Equatable, Hashable {
     let txid: String
     let date: Date
-    let height: UInt32
+    let height: UInt32?
 }

--- a/amstel/VIew/Home/TransactionListView.swift
+++ b/amstel/VIew/Home/TransactionListView.swift
@@ -32,9 +32,15 @@ struct TransactionListView: View {
                 }
                 // Bottom
                 HStack {
-                    Text("Block \(tx.metadata.height)")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                    if let height = tx.metadata.height {
+                        Text("Block \(height)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Unconfirmed")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
                     if let feeRate = tx.feeRate {
                         Text("\(feeRate) sat/vB")
@@ -50,6 +56,10 @@ struct TransactionListView: View {
 
 #Preview {
     @Previewable @State var transaction: [ViewableTransaction] = [
+        ViewableTransaction(netSend: true,
+                            amount: 322,
+                            feeRate: 1,
+                            metadata: TxMetadata(txid: "aaaabbbbccccddddeeeeffffaaaabbbbccccddddeeeeffff", date: Date(), height: nil)),
         ViewableTransaction(netSend: false,
                             amount: 4200,
                             feeRate: nil,

--- a/amstel/amstel.entitlements
+++ b/amstel/amstel.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Requires additional testing for the TX ordering in practice, but the core logic is present here.

Closes #5 