### PR TITLE
Add file import flow

### DIFF
--- a/amstel/Util/ParseFile.swift
+++ b/amstel/Util/ParseFile.swift
@@ -5,7 +5,9 @@
 //  Created by Robert Netzke on 7/2/25.
 //
 import BitcoinDevKit
+import SwiftUICore
 import Foundation
+import UniformTypeIdentifiers
 import KeychainAccess
 
 enum InvalidFileExtension: Error {
@@ -109,3 +111,52 @@ private func importFromTwoPath(_ descriptors: [Descriptor], name: String) throws
                           recvDescriptor: descriptorOne.description,
                           changeDescriptor: descriptorTwo.description)
 }
+
+enum ImportType: String, Identifiable, CaseIterable {
+    case txt
+    case bitcoinCore
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .txt: "Generic"
+        case .bitcoinCore: "Bitcoin Core"
+        }
+    }
+    
+    var fileDescription: String {
+        switch self {
+        case .txt: "A descriptor saved in a txt file"
+        case .bitcoinCore: "JSON in Bitcoin Core format"
+        }
+    }
+
+    var systemImage: Image {
+        switch self {
+        case .txt: Image(systemName: "doc.text")
+        case .bitcoinCore: Image(systemName: "bitcoinsign.circle.fill")
+        }
+    }
+    
+    var importNamedWalletFromFile: (URL, String) throws -> ImportResponse {
+        switch self {
+        case .txt: importWalletFromTxtFile(from:withName:)
+        case .bitcoinCore: importFromBitcoinCoreJson(from:withName:)
+        }
+    }
+
+    var contentType: UTType {
+        switch self {
+        case .txt: .plainText
+        case .bitcoinCore: .json
+        }
+    }
+}
+
+struct ImportFile: Identifiable {
+    var id: UUID = UUID()
+    var url: URL
+    var importType: ImportType
+}
+

--- a/amstel/VIew/Home/ImportSheetView.swift
+++ b/amstel/VIew/Home/ImportSheetView.swift
@@ -1,0 +1,61 @@
+//
+//  ImportSheet.swift
+//  amstel
+//
+//  Created by Robert Netzke on 7/17/25.
+//
+import SwiftUI
+
+struct ImportSheetView: View {
+    @Binding var importFile: ImportFile?
+    @Binding var isShowingImport: Bool
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Choose Import")
+                .font(.headline)
+            Divider()
+            ForEach(ImportType.allCases) { type in
+                Button {
+                    addItem(importType: type)
+                } label: {
+                    HStack {
+                        type.systemImage
+                            .foregroundColor(.accentColor)
+                        VStack(alignment: .leading) {
+                            Text(type.label)
+                                .font(.headline)
+                            Text(type.fileDescription)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding()
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+        .padding()
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Dismiss") {
+                    isShowingImport = false
+                }
+            }
+        }
+    }
+    
+    private func addItem(importType: ImportType) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.text]
+        panel.canChooseDirectories = false
+        panel.begin {
+            response in
+            if response == .OK, let url = panel.url {
+                importFile = ImportFile(url: url, importType: importType)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
The user now has an intermediate screen when selecting a wallet to decide what type of import they are using. This enables future import types without confusion.