### PR TITLE
Add simple transaction details

### DIFF
--- a/amstel/VIew/Home/TransactionListView.swift
+++ b/amstel/VIew/Home/TransactionListView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TransactionListView: View {
     @Binding var transactions: [ViewableTransaction]
+    @State var selectedTx: ViewableTransaction? = nil
 
     var body: some View {
         List(transactions) { tx in
@@ -50,6 +51,13 @@ struct TransactionListView: View {
                     }
                 }
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                selectedTx = tx
+            }
+        }
+        .sheet(item: $selectedTx) { tx in
+            TxDetailView(txBinding: $selectedTx, theTx: tx)
         }
     }
 }

--- a/amstel/VIew/Home/TxDetailView.swift
+++ b/amstel/VIew/Home/TxDetailView.swift
@@ -7,9 +7,45 @@
 import SwiftUI
 
 struct TxDetailView: View {
-    let viewableTx: ViewableTransaction
+    @Binding var txBinding: ViewableTransaction?
+    let theTx: ViewableTransaction
     
     var body: some View {
-        
+        VStack(alignment: .leading) {
+            Text("Transaction Details")
+                .font(.headline)
+            Divider()
+            Group {
+                Text("You \(theTx.netSend ? "sent " : "received ")\(theTx.amount) sats")
+                Divider()
+                Text(theTx.metadata.date.formatted(date: .long, time: .complete))
+                Divider()
+                Text("TXID: \(theTx.metadata.txid)")
+                    .monospaced()
+                    .foregroundStyle(.secondary)
+//                Divider()
+//                Text("Script size: \(theCoin.script)")
+//                    .monospaced()
+//                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Dismiss") {
+                    txBinding = nil
+                }
+            }
+        }
     }
+}
+
+#Preview {
+    @Previewable @State var theTx: ViewableTransaction? = ViewableTransaction(netSend: true,
+                                                              amount: 322,
+                                                              feeRate: 1,
+                                                              metadata: TxMetadata(txid: "aaaabbbbccccddddeeeeffffaaaabbbbccccddddeeeeffff",
+                                                                date: Date(), height: nil))
+    TxDetailView(txBinding: $theTx, theTx: theTx!)
 }


### PR DESCRIPTION
Tap gesture on the transaction list shows some simple metadata. Could be expanded on in the future

Closes #6 