### PR TITLE
Move data to `Library/Amstel`

### DIFF
--- a/amstel/ContentView.swift
+++ b/amstel/ContentView.swift
@@ -108,7 +108,6 @@ struct ContentView: View {
                         notiesEnabled = true
                     }
                 }
-
             }
         } detail: {
             VStack(spacing: 4) {

--- a/amstel/Extensions/BDK.swift
+++ b/amstel/Extensions/BDK.swift
@@ -56,30 +56,39 @@ extension AddressInfo {
 
 extension String {
     static func walletDirectoryPath(id: String) -> String {
-        let documentsDir = URL.documentsDirectory
-        let walletDir = documentsDir.appendingPathComponent(id)
-        return walletDir.path()
+        return URL.walletDirectoryUrl(id: id).path()
     }
 
     static func walletSqliteFile(id: String) -> String {
-        let documentsDir = URL.documentsDirectory
-        let walletDir = documentsDir.appendingPathComponent(id)
+        let walletDir = URL.walletDirectoryUrl(id: id)
         return walletDir.appendingPathComponent("wallet.db").path()
     }
 }
 
 extension URL {
+    static func baseApplicationUrl() -> URL {
+        let appSupport = URL.libraryDirectory
+        let application = appSupport.appendingPathComponent("Amstel")
+        return application
+    }
+    
     static func nodeDirectoryPath() -> URL {
-        let documentsDir = URL.documentsDirectory
-        let nodeDir = documentsDir.appendingPathComponent(".node")
+        let base = URL.baseApplicationUrl()
+        let nodeDir = base.appendingPathComponent(".node")
         return nodeDir
+    }
+    
+    static func walletDirectoryUrl(id: String) -> URL {
+        let base = URL.baseApplicationUrl()
+        let walletDir = base.appendingPathComponent(id)
+        return walletDir
     }
 }
 
 extension Wallet {
     convenience init(recvId: String, recv: String, change: String) throws {
-        let docsDir = URL.documentsDirectory
-        try FileManager.default.createDirectory(at: docsDir.appendingPathComponent(recvId), withIntermediateDirectories: false)
+        let walletDir = URL.walletDirectoryUrl(id: recvId)
+        try FileManager.default.createDirectory(at: walletDir, withIntermediateDirectories: true)
         let recv = try Descriptor(descriptor: recv, network: NETWORK)
         let change = try Descriptor(descriptor: change, network: NETWORK)
         let conn = try Persister.newSqlite(path: String.walletSqliteFile(id: recvId))

--- a/amstel/VIew/WalletView.swift
+++ b/amstel/VIew/WalletView.swift
@@ -221,7 +221,7 @@ struct WalletView: View {
             ScanType.sync
         }
         if !FileManager.default.fileExists(atPath: URL.nodeDirectoryPath().path()) {
-            try FileManager.default.createDirectory(at: URL.nodeDirectoryPath(), withIntermediateDirectories: false)
+            try FileManager.default.createDirectory(at: URL.nodeDirectoryPath(), withIntermediateDirectories: true)
         }
         let conns = UInt8(numConns)
         var builder = CbfBuilder()

--- a/amstel/amstelApp.swift
+++ b/amstel/amstelApp.swift
@@ -28,7 +28,6 @@ struct amstelApp: App {
             ContentView()
                 .navigationTitle("")
         }
-//        .windowStyle(.hiddenTitleBar)
         .modelContainer(sharedModelContainer)
     }
 }


### PR DESCRIPTION
Unfortunately "Application Support" is causing issues in Rust when attempting to create a file using a directory with escaped characters. Although non-standard, `Library/Amstel` is a reasonable folder to store data IMO, and is a work-around that does not used escaped characters.